### PR TITLE
Sync with fprime@devel & Add std::atomic for rpi_pico

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,15 @@ if (FPRIME_CI_FAILSAFE_ENABLED)
     add_compile_definitions(FPRIME_CI_FAILSAFE_CYCLE_COUNT=${FPRIME_CI_FAILSAFE_CYCLE_COUNT})
 endif()
 
+# Configure custom atomic implementation for RP2040 boards
+if(BOARD STREQUAL "rpi_pico")
+    message(STATUS "[INFO] Configuring custom atomic implementation for ${BOARD}")
+
+    # Add include directory to override <atomic> header and allow use of std::atomic
+    include_directories(BEFORE SYSTEM "${CMAKE_CURRENT_LIST_DIR}/lib/fprime-zephyr/fprime-zephyr/Os/StdAtomic")
+
+endif()
+
 ###
 # F' Core Setup
 # This includes all of the F prime core components, and imports the make-system.

--- a/boards/rpi_pico.overlay
+++ b/boards/rpi_pico.overlay
@@ -1,0 +1,5 @@
+&zephyr_udc0 {
+    cdc_acm_uart0: cdc_acm_uart0 {
+        compatible = "zephyr,cdc-acm-uart";
+    };
+};

--- a/fprime-zephyr-reference/ReferenceDeployment/Top/instances.fpp
+++ b/fprime-zephyr-reference/ReferenceDeployment/Top/instances.fpp
@@ -33,7 +33,7 @@ module ReferenceDeployment {
       stack size Default.STACK_SIZE \
       priority 10 \
 
-  instance eventLogger: Svc.ActiveLogger base id 0x0B00 \
+  instance eventLogger: Svc.EventManager base id 0x0B00 \
     queue size Default.QUEUE_SIZE \
     stack size Default.STACK_SIZE \
     priority 9

--- a/fprime-zephyr-reference/project/config/FpConfig.h
+++ b/fprime-zephyr-reference/project/config/FpConfig.h
@@ -26,13 +26,13 @@ extern "C" {
 
 // Define enumeration for Time base types
 // Note: maintaining C-style
-typedef enum {
-    TB_NONE,              //!< No time base has been established
-    TB_PROC_TIME,         //!< Indicates time is processor cycle time. Not tied to external time
-    TB_WORKSTATION_TIME,  //!< Time as reported on workstation where software is running. For testing.
-    TB_DONT_CARE =
-        0xFFFF  //!< Don't care value for sequences. If FwTimeBaseStoreType is changed, value should be changed
-} TimeBase;
+// typedef enum {
+//     TB_NONE,              //!< No time base has been established
+//     TB_PROC_TIME,         //!< Indicates time is processor cycle time. Not tied to external time
+//     TB_WORKSTATION_TIME,  //!< Time as reported on workstation where software is running. For testing.
+//     TB_DONT_CARE =
+//         0xFFFF  //!< Don't care value for sequences. If FwTimeBaseStoreType is changed, value should be changed
+// } TimeBase;
 #define FW_CONTEXT_DONT_CARE 0xFF  //!< Don't care value for time contexts in sequences
 
 // ----------------------------------------------------------------------

--- a/fprime-zephyr-reference/project/config/FpConfig.h
+++ b/fprime-zephyr-reference/project/config/FpConfig.h
@@ -22,17 +22,6 @@ extern "C" {
 // Type aliases
 // ----------------------------------------------------------------------
 
-
-
-// Define enumeration for Time base types
-// Note: maintaining C-style
-// typedef enum {
-//     TB_NONE,              //!< No time base has been established
-//     TB_PROC_TIME,         //!< Indicates time is processor cycle time. Not tied to external time
-//     TB_WORKSTATION_TIME,  //!< Time as reported on workstation where software is running. For testing.
-//     TB_DONT_CARE =
-//         0xFFFF  //!< Don't care value for sequences. If FwTimeBaseStoreType is changed, value should be changed
-// } TimeBase;
 #define FW_CONTEXT_DONT_CARE 0xFF  //!< Don't care value for time contexts in sequences
 
 // ----------------------------------------------------------------------

--- a/prj.conf
+++ b/prj.conf
@@ -1,11 +1,15 @@
 #### Configure Device VID and PID --> Uncomment the desired device definitions ####
 
-#### From Teensy41 USB definitions #### 
+#### From Teensy41 USB definitions ####
 CONFIG_USB_DEVICE_VID=0x16C0
 CONFIG_USB_DEVICE_PID=0x0483
 
-#### From Raspberry Pi Pico2 USB Definitions #### 
+#### From Raspberry Pi Pico2 USB Definitions ####
 # CONFIG_USB_DEVICE_PID=0x000F
+# CONFIG_USB_DEVICE_VID=0x2E8A
+
+#### From Raspberry Pi Pico USB Definitions ####
+# CONFIG_USB_DEVICE_PID=0x0003
 # CONFIG_USB_DEVICE_VID=0x2E8A
 
 #### F Prime C++ Dependencies ####
@@ -22,7 +26,7 @@ CONFIG_REBOOT=y
 CONFIG_USB_DEVICE_STACK=y
 CONFIG_USB_CDC_ACM=y
 CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=y
-CONFIG_UART_INTERRUPT_DRIVEN=y 
+CONFIG_UART_INTERRUPT_DRIVEN=y
 
 #### Serial and I/O ####
 CONFIG_CONSOLE=y
@@ -33,15 +37,17 @@ CONFIG_PWM=n
 CONFIG_I2C=n
 CONFIG_SPI=n
 CONFIG_PINCTRL=y
-CONFIG_ASSERT=y 
+CONFIG_ASSERT=y
 
-CONFIG_DYNAMIC_THREAD=y 
+CONFIG_DYNAMIC_THREAD=y
 CONFIG_KERNEL_MEM_POOL=y
-CONFIG_DYNAMIC_THREAD_ALLOC=n 
+CONFIG_DYNAMIC_THREAD_ALLOC=n
 CONFIG_DYNAMIC_THREAD_PREFER_POOL=y
 CONFIG_MAIN_THREAD_PRIORITY=14
-CONFIG_DYNAMIC_THREAD_POOL_SIZE=10 # Num threads in the thread pool 
-CONFIG_DYNAMIC_THREAD_STACK_SIZE=8192 # Size of thread stack in thread pool, must be >= Thread Pool size in F' 
+CONFIG_DYNAMIC_THREAD_POOL_SIZE=10
+    # Num threads in the thread pool
+CONFIG_DYNAMIC_THREAD_STACK_SIZE=8192
+    # Size of thread stack in thread pool, must be >= Thread Pool size in F'
 
 CONFIG_THREAD_STACK_INFO=y
 CONFIG_RING_BUFFER=y


### PR DESCRIPTION
This change is dependent on `fprime-zephyr` update to https://github.com/fprime-community/fprime-zephyr/pull/11

This update supports latest versions of fprime:
* ActiveLogger -> EventManager (corresponding to https://github.com/nasa/fprime/commit/7ec2bb9a762251dff5ce625c76b3b1caee3e2eb2)
* Removing config TimeBase enum from C header file (corresponding to https://github.com/nasa/fprime/issues/3783)