### PR TITLE
Updates to include fprime-sensors submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/fprime-zephyr"]
 	path = lib/fprime-zephyr
 	url = https://github.com/fprime-community/fprime-zephyr.git
+[submodule "lib/fprime-sensors"]
+	path = lib/fprime-sensors
+	url = https://github.com/fprime-community/fprime-sensors.git

--- a/FprimeZephyrReference/ReferenceDeployment/Main.cpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Main.cpp
@@ -9,6 +9,7 @@
 #include <zephyr/kernel.h>
 
 const struct device *serial = DEVICE_DT_GET(DT_NODELABEL(cdc_acm_uart0));
+const struct i2c_dt_spec imuDevice = DT_NODELABEL(lpi2c1);
 
 int main(int argc, char* argv[]) {
     // ** DO NOT REMOVE **//
@@ -22,6 +23,7 @@ int main(int argc, char* argv[]) {
     ReferenceDeployment::TopologyState inputs;
     inputs.uartDevice = serial;
     inputs.baudRate = 115200;
+    inputs.mpu.device = imuDevice; 
  
     // Setup, cycle, and teardown topology
     ReferenceDeployment::setupTopology(inputs);

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentPackets.fppi
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentPackets.fppi
@@ -17,7 +17,7 @@ telemetry packets ReferenceDeploymentPackets {
   }
 
 
-  packet HealthAuxillary id 3 group 2 {
+  packet HealthAuxillary id 3 group 3 {
     ComCcsds.commsBufferManager.TotalBuffs
     ComCcsds.commsBufferManager.CurrBuffs
     ComCcsds.comQueue.buffQueueDepth
@@ -28,6 +28,10 @@ telemetry packets ReferenceDeploymentPackets {
     CdhCore.version.FrameworkVersion
     CdhCore.version.ProjectVersion
     CdhCore.version.LibraryVersion01
+  }
+
+  packet Imu id 5 group 2 {
+    MpuImu.imuManager.Reading
   }
 
 

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopology.hpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopology.hpp
@@ -9,6 +9,7 @@
 // autocoder, but are also used in this hand-coded topology.
 #include <FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopologyDefs.hpp>
 
+
 // Remove unnecessary ReferenceDeployment:: qualifications
 using namespace ReferenceDeployment;
 namespace ReferenceDeployment {

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopologyDefs.hpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopologyDefs.hpp
@@ -6,6 +6,8 @@
 #ifndef REFERENCEDEPLOYMENT_REFERENCEDEPLOYMENTTOPOLOGYDEFS_HPP
 #define REFERENCEDEPLOYMENT_REFERENCEDEPLOYMENTTOPOLOGYDEFS_HPP
 
+#include "fprime-sensors/MpuImu/Subtopology/SubtopologyTopologyDefs.hpp"
+
 // Subtopology PingEntries includes
 #include "Svc/Subtopologies/CdhCore/PingEntries.hpp"
 #include "Svc/Subtopologies/ComCcsds/PingEntries.hpp"
@@ -64,6 +66,8 @@ struct TopologyState {
     U32 baudRate;          //!< Baud rate for UART communication
     CdhCore::SubtopologyState cdhCore;           //!< Subtopology state for CdhCore
     ComCcsds::SubtopologyState comCcsds;         //!< Subtopology state for ComCcsds 
+    MpuImu::SubtopologyState mpu;
+
 };
 
 namespace PingEntries = ::PingEntries;

--- a/FprimeZephyrReference/ReferenceDeployment/Top/topology.fpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/topology.fpp
@@ -16,7 +16,9 @@ module ReferenceDeployment {
   # ----------------------------------------------------------------------
     import CdhCore.Subtopology
     import ComCcsds.Subtopology
-    
+    # import NmeaGps.Subtopology
+    import MpuImu.Subtopology
+
   # ----------------------------------------------------------------------
   # Instances used in the topology
   # ----------------------------------------------------------------------

--- a/FprimeZephyrReference/project/config/CMakeLists.txt
+++ b/FprimeZephyrReference/project/config/CMakeLists.txt
@@ -12,5 +12,8 @@ register_fprime_config(
         "${CMAKE_CURRENT_LIST_DIR}/CommandDispatcherImplCfg.hpp"
         "${CMAKE_CURRENT_LIST_DIR}/FpConfig.h"
         "${CMAKE_CURRENT_LIST_DIR}/TlmPacketizerCfg.hpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MpuImuSubtopologyConfig.fpp"
+        "${CMAKE_CURRENT_LIST_DIR}/MpuImuSubtopologyConfig.hpp"
+
     INTERFACE
 )

--- a/FprimeZephyrReference/project/config/MpuImuSubtopologyConfig.fpp
+++ b/FprimeZephyrReference/project/config/MpuImuSubtopologyConfig.fpp
@@ -1,0 +1,16 @@
+module MpuImu {
+    module SubtoplogyConfig {
+        constant BASE_ID = 0xE0000000
+    }
+
+    instance imuDriver: Zephyr.ZephyrI2CDriver base id MpuImu.SubtoplogyConfig.BASE_ID + 0x00002000 {
+        phase Fpp.ToCpp.Phases.configComponents """
+        if (not MpuImu::imuDriver.open(state.mpu.device)) {
+            Fw::Logger::log("[ERROR] MPU IMU open failed\\n");
+        }
+        else {
+            Fw::Logger::log("[INFO] MPU IMU open successful\\n");
+        }
+        """
+    }
+}

--- a/FprimeZephyrReference/project/config/MpuImuSubtopologyConfig.hpp
+++ b/FprimeZephyrReference/project/config/MpuImuSubtopologyConfig.hpp
@@ -1,0 +1,11 @@
+// ======================================================================
+// \title  MpuImuSubtopologyConfig.hpp
+// \brief required header file containing the required definitions for the subtopology autocoder
+//
+// ======================================================================
+#ifndef MpuImu_MpuImuSubtopologyConfig_hpp
+#define MpuImu_MpuImuSubtopologyConfig_hpp
+
+using ImuDevice = struct i2c_dt_spec;
+
+#endif // MpuImu_MpuImuSubtopologyConfig_hpp

--- a/boards/teensy41.overlay
+++ b/boards/teensy41.overlay
@@ -13,3 +13,15 @@
 	status = "okay";
 	current-speed = < 115200 >;
 };
+
+&lpi2c1 {
+	status = "okay";
+};
+
+/ {
+    chosen {
+        zephyr,console = &cdc_acm_uart0;
+		imu = &lpi2c1; 
+    };
+};
+

--- a/prj.conf
+++ b/prj.conf
@@ -1,12 +1,12 @@
 #### Configure Device VID and PID --> Uncomment the desired device definitions ####
 
 #### From Teensy41 USB definitions #### 
-# CONFIG_USB_DEVICE_VID=0x16C0
-# CONFIG_USB_DEVICE_PID=0x0483
+CONFIG_USB_DEVICE_VID=0x16C0
+CONFIG_USB_DEVICE_PID=0x0483
 
 #### From Raspberry Pi Pico2 USB Definitions #### 
-CONFIG_USB_DEVICE_PID=0x000F
-CONFIG_USB_DEVICE_VID=0x2E8A
+# CONFIG_USB_DEVICE_PID=0x000F
+# CONFIG_USB_DEVICE_VID=0x2E8A
 
 #### From Raspberry Pi Pico USB Definitions ####
 # CONFIG_USB_DEVICE_PID=0x0003

--- a/settings.ini
+++ b/settings.ini
@@ -1,9 +1,9 @@
 [fprime]
 project_root: .
 framework_path: ./lib/fprime
-library_locations: ./lib/fprime-zephyr
+library_locations: ./lib/fprime-zephyr:./lib/fprime-sensors
 default_toolchain: zephyr
 
 default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
                         FPRIME_ENABLE_AUTOCODER_UTS=OFF
-                        BOARD=rpi_pico2/rp2350a/m33
+                        BOARD=teensy41


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n/a |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |
|**_Generative AI was used in this contribution (y/n)_**| n |

---
## Change Description

<!-- A description of the changes contained in the PR. -->
Updates to Top level files to have relevant updates to have the fprime-sensors submodule properly connected. 

## Rationale

<!-- A rationale for this change. e.g. fixes bug, or most projects need XYZ feature. -->
Wanting to have the [fprime-zephyr-reference ](https://github.com/fprime-community/fprime-zephyr-reference)work with the [fprime-sensors](https://github.com/fprime-community/fprime-sensors) library.


## Testing/Review Recommendations

<!-- Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality. -->
Relevant error message: 
```
error: 'DT_N_S_soc_S_i2c_403f0000' was not declared in this scope; did you mean 'DT_N_S_soc_S_i2c_403f0000_ORD'?
49557 | #define DT_N_NODELABEL_lpi2c1 DT_N_S_soc_S_i2c_403f0000
``` 

## Future Work

<!-- Note any additional work that will be done relating to this issue. -->
This work is incomplete. Current issues seems to be with the i2c driver. 
Future work: testing SPI driver and ensuring it also can work. 

## AI Usage (see [policy](https://github.com/nasa/fprime/blob/devel/AI_POLICY.md))

<!-- If AI was used, please describe how it was utilized (e.g., code generation, documentation, testing, debugging assistance, etc.). -->
n/a