### PR TITLE
Use Zephyr kmalloc-backed allocator in deployment

### DIFF
--- a/FprimeZephyrReference/ReferenceDeployment/Top/CMakeLists.txt
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/CMakeLists.txt
@@ -16,6 +16,7 @@ register_fprime_module(
         "${CMAKE_CURRENT_LIST_DIR}/topology.fpp"
     SOURCES
         "${CMAKE_CURRENT_LIST_DIR}/ReferenceDeploymentTopology.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/ZephyrKmallocAllocator.cpp"
     DEPENDS
         Fw_Logger
 )

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopology.cpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentTopology.cpp
@@ -8,14 +8,14 @@
 // Note: Uncomment when using Svc:TlmPacketizer
 //#include <FprimeZephyrReference/ReferenceDeployment/Top/ReferenceDeploymentPacketsAc.hpp>
 
-// Necessary project-specified types
-#include <Fw/Types/MallocAllocator.hpp>
+// Deployment-local allocator backed by Zephyr's system heap
+#include <FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.hpp>
 
 // Allows easy reference to objects in FPP/autocoder required namespaces
 using namespace ReferenceDeployment;
 
-// Instantiate a malloc allocator for cmdSeq buffer allocation
-Fw::MallocAllocator mallocator;
+// Instantiate a Zephyr-backed allocator for cmdSeq buffer allocation
+ReferenceDeployment::ZephyrKmallocAllocator mallocator;
 
 constexpr FwSizeType BASE_RATEGROUP_PERIOD_MS = 1; // 1Khz 
 

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.cpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.cpp
@@ -1,0 +1,47 @@
+#include <FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.hpp>
+
+#include <zephyr/kernel.h>
+
+namespace ReferenceDeployment {
+
+bool ZephyrKmallocAllocator::isPowerOfTwo(const FwSizeType value) {
+    return (value != 0U) && ((value & (value - 1U)) == 0U);
+}
+
+FwSizeType ZephyrKmallocAllocator::normalizeAlignment(FwSizeType alignment) {
+    const auto pointerAlignment = static_cast<FwSizeType>(sizeof(void*));
+    if (alignment < pointerAlignment) {
+        return pointerAlignment;
+    }
+    return alignment;
+}
+
+void* ZephyrKmallocAllocator::allocate(const FwEnumStoreType identifier,
+                                       FwSizeType& size,
+                                       bool& recoverable,
+                                       FwSizeType alignment) {
+    static_cast<void>(identifier);
+
+    recoverable = false;
+    if (size == 0U) {
+        return nullptr;
+    }
+
+    alignment = normalizeAlignment(alignment);
+    if (!isPowerOfTwo(alignment)) {
+        return nullptr;
+    }
+
+    if (alignment <= static_cast<FwSizeType>(sizeof(void*))) {
+        return k_malloc(size);
+    }
+
+    return k_aligned_alloc(alignment, size);
+}
+
+void ZephyrKmallocAllocator::deallocate(const FwEnumStoreType identifier, void* ptr) {
+    static_cast<void>(identifier);
+    k_free(ptr);
+}
+
+}  // namespace ReferenceDeployment

--- a/FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.hpp
+++ b/FprimeZephyrReference/ReferenceDeployment/Top/ZephyrKmallocAllocator.hpp
@@ -1,0 +1,29 @@
+#ifndef REFERENCEDEPLOYMENT_ZEPHYRKMALLOCALLOCATOR_HPP
+#define REFERENCEDEPLOYMENT_ZEPHYRKMALLOCALLOCATOR_HPP
+
+#include <Fw/Types/MemAllocator.hpp>
+
+#include <cstddef>
+
+namespace ReferenceDeployment {
+
+class ZephyrKmallocAllocator final : public Fw::MemAllocator {
+  public:
+    ZephyrKmallocAllocator() = default;
+    ~ZephyrKmallocAllocator() override = default;
+
+    void* allocate(FwEnumStoreType identifier,
+                   FwSizeType& size,
+                   bool& recoverable,
+                   FwSizeType alignment = alignof(std::max_align_t)) override;
+
+    void deallocate(FwEnumStoreType identifier, void* ptr) override;
+
+  private:
+    static bool isPowerOfTwo(FwSizeType value);
+    static FwSizeType normalizeAlignment(FwSizeType alignment);
+};
+
+}  // namespace ReferenceDeployment
+
+#endif

--- a/prj.conf
+++ b/prj.conf
@@ -7,7 +7,9 @@ CONFIG_CPP=y
 CONFIG_REQUIRES_FULL_LIBCPP=y
     # ...in full capacity
 CONFIG_COMMON_LIBC_MALLOC=y
-    # LIBC malloc calls are needed for Fw::MemAllocator
+    # Retained until imported modules are audited for any remaining libc malloc use
+CONFIG_HEAP_MEM_POOL_SIZE=8192
+    # Enable Zephyr's system heap for the deployment-local k_malloc/k_free allocator
 CONFIG_DYNAMIC_THREAD=y
     # Threads are built at runtime...
 CONFIG_DYNAMIC_THREAD_ALLOC=n


### PR DESCRIPTION
This PR replaces the deployment-local use of `Fw::MallocAllocator` with a Zephyr-backed `Fw::MemAllocator` implementation.

`ReferenceDeployment` now uses a new `ZephyrKmallocAllocator` that allocates from Zephyr’s system heap with `k_malloc()` / `k_aligned_alloc()` and frees with `k_free()`. This keeps the allocator swap scoped to the deployment instead of changing framework-wide allocator behavior.

The PR also enables Zephyr’s system heap in prj.conf with `CONFIG_HEAP_MEM_POOL_SIZE=8192`, and updates the topology/CMake wiring so the new allocator is compiled and used for command sequence buffer allocation.

**Why**

The current deployment was relying on libc malloc via `Fw::MallocAllocator`. For Zephyr targets, it is cleaner to route this allocation path through Zephyr’s heap APIs so allocation behavior is owned by the RTOS instead of the libc layer.

**Implementation Notes**

  - Adds `ZephyrKmallocAllocator` under `ReferenceDeployment/Top`
  - Preserves the `Fw::MemAllocator` interface expected by F´
  - Uses aligned allocation when requested alignment exceeds pointer-size alignment
  - Leaves `CONFIG_COMMON_LIBC_MALLOC=y` in place for now until the wider imported codebase is audited for any remaining libc allocator dependencies

**Testing**

  - Configured and built successfully for `BOARD=teensy41`
  - Produced final Zephyr artifacts including zephyr.elf and zephyr.hex

**Reference**
https://docs.zephyrproject.org/latest/kernel/memory_management/heap.html
